### PR TITLE
Fix recursive globbing

### DIFF
--- a/codeclimate-pylint
+++ b/codeclimate-pylint
@@ -21,7 +21,7 @@ def process_python_files_in_paths(paths, process):
         if path.endswith('.py'):
             process(path)
         if path.endswith('/'):
-            subpaths = glob.glob(path + "*.py") + glob.glob(path + "*/**/*.py")
+            subpaths = glob.glob(path + "*.py") + glob.glob(path + "*/**/*.py", recursive=True)
             for subpath in subpaths:
                 process(subpath)
 


### PR DESCRIPTION
The [documentation](https://docs.python.org/3.6/library/glob.html#glob.glob) states that `recursive` is set to `False` by default, preventing recursive matches.