### PR TITLE
Support configuring additional PYTHONPATH paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ You can configure which files to be analyzed in your `.codeclimate.yml` file.
 
 Other configurations can be made through a `.pylintrc` file. More information can be found on [Pylint's documentation](https://pylint.readthedocs.io/en/latest/)
 
+PYTHONPATH can be modified by setting the PYTHONPATH configuration variable:
+
+```yaml
+engines:
+  pylint:
+    enabled: true
+    channel: "beta"
+    PYTHONPATH:
+      - src
+```
+
+This adds the `src` directory to PYTHONPATH before running `pylint`. Relative paths are properly resolved to the current directory.
+
 Plugin activation can also be made in `.codeclimate.yml`:
 
 ```

--- a/codeclimate-pylint
+++ b/codeclimate-pylint
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import glob, json
+import glob, json, os.path, sys
 
 from pylint.lint import Run
 from reporter import CodeClimateReporter
@@ -14,6 +14,12 @@ except IOError:
 include_paths = config.get('include_paths', ['./'])
 exclude_paths = config.get('exclude_paths', [])
 plugins_config = config.get('plugins', [])
+
+additional_python_path = config.get('PYTHONPATH', [])
+if isinstance(additional_python_path, str):
+    additional_python_path = [additional_python_path]
+sys.path.extend(map(lambda x: os.path.abspath(x), additional_python_path))
+print("Running pylint using PYTHONPATH: " + (":".join(sys.path)), file=sys.stderr)
 
 
 def process_python_files_in_paths(paths, process):


### PR DESCRIPTION
This adds the ability to add additional locations in the repository to PYTHONPATH, so that absolute imports can be resolved from pylint.

Sample .codeclimate.yml:
```yaml
plugins:
  pylint:
    enabled: true
    channel: "beta"
    PYTHONPATH:
      - src
```

This can in theory be solved by adding an init-hook, but that can affect pylint depending on the directory in which it is invoked (e.g. using `.` and running pylint from a different directory)